### PR TITLE
Allow % sign in password

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -75,7 +75,7 @@ if D:
 # == read monitor in monitor.cfg ===========================
 parser = configparser.ConfigParser()
 parser.read(get_filepath("monitor.cfg"))
-monitor_settings = dict(parser.items("monitor"))
+monitor_settings = dict(parser.items("monitor",raw=True))
 
 REGION = monitor_settings["region"]
 BRAND = monitor_settings["brand"]


### PR DESCRIPTION
By default, the % sign is used by configparser to allow interpolation of entries, so you can chain things together. As that won't be used here, and people might have a % sign in their passord, it is better to disable interpolation.