### PR TITLE
Add files to create and run a Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3-alpine
+
+WORKDIR /usr/src/hyundai_kia_connect_monitor
+COPY ./hyundai_kia_connect_monitor/* ./
+COPY ca-certificates.crt mqtt_utils.py ./
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir "paho_mqtt>=2.0"
+ENV HOME=/usr/src
+ENTRYPOINT [ "python", "-u", "./monitor.py" ]
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,5 +7,5 @@ the standard way, it should be copied to `../..`. The Docker-Compose file
 csv-files go into the same directory. You may need to create them first, for 
 example with `touch monitor.csv`.
 
-If you are not familiar with Docker, see the [Docker Compose Quickstart|https://docs.docker.com/compose/gettingstarted/] for an introduction to `docker compose` and a guide to the commands required.
+If you are not familiar with Docker, see the [Docker Compose Quickstart](https://docs.docker.com/compose/gettingstarted/) for an introduction to `docker compose` and a guide to the commands required.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,11 @@
+# Run hyundai_kia_connect_monitor in a Docker container 
+If you want to run hyundai_kia_connect_monitor in a Docker container, use the 
+files in this directory. The `Dockerfile` assumes that the monitor code is in 
+the subdirectory `hyundai_kia_connect_monitor`, so if you cloned this repository
+the standard way, it should be copied to `../..`. The Docker-Compose file 
+`compose.yaml` shall be in the same direcory. It assumes that the cfg- and 
+csv-files go into the same directory. You may need to create them first, for 
+example with `touch monitor.csv`.
+
+If you are not familiar with Docker, see the [Docker Compose Quickstart|https://docs.docker.com/compose/gettingstarted/] for an introduction to `docker compose` and a guide to the commands required.
+

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  hyundai:
+    build: .
+    volumes:
+      - ./monitor.cfg:/usr/src/hyundai_kia_connect_monitor/monitor.cfg
+      - ./monitor.csv:/usr/src/hyundai_kia_connect_monitor/monitor.csv
+      - ./monitor.dailystats.csv:/usr/src/hyundai_kia_connect_monitor/monitor.dailystats.csv
+      - ./monitor.tripinfo.csv:/usr/src/hyundai_kia_connect_monitor/monitor.tripinfo.csv
+      - ./summary.cfg:/usr/src/hyundai_kia_connect_monitor/summary.cfg
+      - ./summary.charge.csv:/usr/src/hyundai_kia_connect_monitor/summary.charge.csv
+      - ./summary.trip.csv:/usr/src/hyundai_kia_connect_monitor/summary.trip.csv
+


### PR DESCRIPTION
A simple configuration and documentation to create a Docker image for hyundai_kia_connect_monitor and run it continuously with Docker Compose.